### PR TITLE
【改善】pr-agentの実行条件の修正

### DIFF
--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -1,8 +1,6 @@
 name: pr-agent
 
 on:
-  pull_request:
-    types: [opened, reopened, review_requested]
   issue_comment:
     types: [created, edited]
 
@@ -14,22 +12,25 @@ jobs:
   pr_agent:
     runs-on: ubuntu-latest
     name: Run PR Agent
-    if: ${{ github.event.sender.type != 'Bot' }}
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/run-pr-agent') &&
+      github.event.sender.type != 'Bot'
     steps:
       - id: pr-agent
         uses: Codium-ai/pr-agent@main
         env:
-          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IGNORE_PR_LABELS: '["WIP", "ignore-pr-review"]' 
+          IGNORE_PR_LABELS: '["ignore-pr-review"]'
           PR_DESCRIPTION.CUSTOM_LABELS: "[]"
           PUBLISH_LABELS: "false"
           PR_REVIEWER.ENABLE_REVIEW_LABELS_EFFORT: "false"
-          PR_DESCRIPTION.ENABLE_PR_TYPE: "false" 
+          PR_DESCRIPTION.ENABLE_PR_TYPE: "false"
           PR_REVIEWER.PERSISTENT_COMMENT: "true"
           PR_CODE_SUGGESTIONS.PERSISTENT_COMMENT: "true"
           PR_ADD_DOCS.PERSISTENT_COMMENT: "true"
           PR_REVIEWER.INLINE_CODE_COMMENTS: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS:      '日本語で記述してください。'
-          PR_REVIEWER.EXTRA_INSTRUCTIONS:         '日本語で記述してください。'
-          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: '日本語で回答してください。'
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "日本語で回答してください。"


### PR DESCRIPTION
### **Description**
- The GitHub Actions workflow for the PR agent has been updated to trigger on `issue_comment` events instead of `pull_request`.
- The `if` condition now checks for comments containing `/run-pr-agent` and ensures the sender is not a bot.
- Environment variable names have been standardized, and the "WIP" label has been removed from `IGNORE_PR_LABELS`.
- Instructions for Japanese language output have been formatted consistently.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yaml</strong><dd><code>Update workflow trigger and conditions for PR agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yaml

<li>Changed the trigger condition from <code>pull_request</code> to <code>issue_comment</code>.<br> <li> Updated the <code>if</code> condition to check for pull request comments.<br> <li> Modified environment variable names and values for consistency.<br> <li> Removed "WIP" from <code>IGNORE_PR_LABELS</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/nana399/remix-tutorial/pull/30/files#diff-74cc68580425f6daeaef927a1a277fa13114d41479d6d4caab2975ca795585a0">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information