### PR TITLE
Update pr-agent.yaml

### DIFF
--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -1,6 +1,8 @@
 name: pr-agent
 
 on:
+  pull_request:
+    types: [opened, reopened, review_requested]
   issue_comment:
     types: [created, edited]
 
@@ -12,25 +14,22 @@ jobs:
   pr_agent:
     runs-on: ubuntu-latest
     name: Run PR Agent
-    if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/run-pr-agent') &&
-      github.event.sender.type != 'Bot'
+    if: ${{ github.event.sender.type != 'Bot' }}
     steps:
       - id: pr-agent
         uses: Codium-ai/pr-agent@main
         env:
-          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IGNORE_PR_LABELS: '["ignore-pr-review"]'
+          IGNORE_PR_LABELS: '["WIP", "ignore-pr-review"]' 
           PR_DESCRIPTION.CUSTOM_LABELS: "[]"
           PUBLISH_LABELS: "false"
           PR_REVIEWER.ENABLE_REVIEW_LABELS_EFFORT: "false"
-          PR_DESCRIPTION.ENABLE_PR_TYPE: "false"
+          PR_DESCRIPTION.ENABLE_PR_TYPE: "false" 
           PR_REVIEWER.PERSISTENT_COMMENT: "true"
           PR_CODE_SUGGESTIONS.PERSISTENT_COMMENT: "true"
           PR_ADD_DOCS.PERSISTENT_COMMENT: "true"
           PR_REVIEWER.INLINE_CODE_COMMENTS: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
-          PR_REVIEWER.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
-          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "日本語で回答してください。"
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS:      '日本語で記述してください。'
+          PR_REVIEWER.EXTRA_INSTRUCTIONS:         '日本語で記述してください。'
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: '日本語で回答してください。'


### PR DESCRIPTION
### **Description**
- Added `pull_request` event trigger for types `opened`, `reopened`, and `review_requested` to the workflow.
- Simplified the condition to run the PR Agent job by removing specific comment checks.
- Updated the `OPENAI_KEY` environment variable to `OPENAI_API_KEY`.
- Included additional labels in `IGNORE_PR_LABELS` to ignore "WIP" PRs.
- Adjusted the formatting of extra instructions for consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yaml</strong><dd><code>Enhance PR Agent workflow with new triggers and conditions</code></dd></summary>
<hr>

.github/workflows/pr-agent.yaml

<li>Added <code>pull_request</code> trigger for specific types.<br> <li> Simplified the condition for running the PR Agent job.<br> <li> Updated environment variable names and values.<br> <li> Adjusted extra instructions formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/nana399/remix-tutorial/pull/37/files#diff-74cc68580425f6daeaef927a1a277fa13114d41479d6d4caab2975ca795585a0">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information