### PR TITLE
Update pr-agent.yaml

### DIFF
--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -2,8 +2,6 @@
 name: pr-agent
 
 on:
-  pull_request:
-    types: [opened]
   issue_comment:
     types: [created, edited]
 


### PR DESCRIPTION
### **Description**
- The GitHub Actions workflow configuration file `pr-agent.yaml` was updated.
- Removed the trigger for `pull_request` events of type `opened`.
- The workflow now only triggers on `issue_comment` events of types `created` and `edited`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yaml</strong><dd><code>Modify GitHub Actions workflow triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yaml

<li>Removed the <code>pull_request</code> event trigger for type <code>opened</code>.<br> <li> Retained the <code>issue_comment</code> event trigger for types <code>created</code> and <code>edited</code>.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/nana399/remix-tutorial/pull/55/files#diff-74cc68580425f6daeaef927a1a277fa13114d41479d6d4caab2975ca795585a0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information